### PR TITLE
vicky: remove vnor for Jio 5G

### DIFF
--- a/overlay/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/CarrierConfig/res/xml/vendor.xml
@@ -18,7 +18,7 @@
             <item value="332|Q.850;cause=21|510" />
         </string-array>
         <boolean name="carrier_allow_transfer_ims_call_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="001" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2592,7 +2592,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="854">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2605,7 +2605,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="855">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2618,7 +2618,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="856">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2631,7 +2631,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="857">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2644,7 +2644,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="858">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2657,7 +2657,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="859">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2670,7 +2670,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="860">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2683,7 +2683,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="861">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2696,7 +2696,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="862">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2709,7 +2709,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="863">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2722,7 +2722,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="864">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2735,7 +2735,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="865">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2748,7 +2748,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="866">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2761,7 +2761,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="867">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2774,7 +2774,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="868">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2787,7 +2787,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="869">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2800,7 +2800,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="870">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2813,7 +2813,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="871">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2826,7 +2826,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="872">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2839,7 +2839,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="873">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2852,7 +2852,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="874">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2865,7 +2865,7 @@
         <boolean name="carrier_name_override_bool" value="false" />
         <string name="carrier_name_string" />
         <int name="ims_conference_size_limit_int" value="9" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="51">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2874,7 +2874,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="52">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2883,7 +2883,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="53">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2892,7 +2892,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="54">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2901,7 +2901,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="55">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2910,7 +2910,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="56">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2919,7 +2919,7 @@
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
         <boolean name="editable_wfc_mode_bool" value="false" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="66">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2928,7 +2928,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="67">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2937,7 +2937,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="750">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2946,7 +2946,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="751">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2955,7 +2955,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="752">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2964,7 +2964,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="753">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2973,7 +2973,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="754">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2982,7 +2982,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="755">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -2991,7 +2991,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="756">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3000,7 +3000,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="70">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3009,7 +3009,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="799">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3018,7 +3018,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="845">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3027,7 +3027,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="846">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3036,13 +3036,13 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="847">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="848">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3051,7 +3051,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="849">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3060,7 +3060,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="850">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3069,13 +3069,13 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="851">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="852">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3084,7 +3084,7 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="853">
         <boolean name="carrier_volte_available_bool" value="true" />
@@ -3093,31 +3093,31 @@
         <int name="carrier_default_wfc_ims_mode_int" value="2" />
         <boolean name="carrier_default_wfc_ims_enabled_bool" value="true" />
         <boolean name="editable_wfc_mode_bool" value="false" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="908">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="909">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="910">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="405" mnc="911">
         <boolean name="carrier_volte_available_bool" value="true" />
         <boolean name="carrier_wfc_ims_available_bool" value="true" />
         <boolean name="carrier_vt_available_bool" value="true" />
-        <boolean name="vonr_enabled_bool" value="true" />
+        
     </carrier_config>
     <carrier_config mcc="410" mnc="01">
         <boolean name="carrier_volte_available_bool" value="true" />


### PR DESCRIPTION
Device doesn't support 5G, so we don't require this stuff